### PR TITLE
Improve API namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ px.to_parquet
 px.read_sfdc
 px.sfdc_metadata
 px.patch_sfdc
-px.async_patch
+px.async_patch_sfdc
 
 px.read_sql
 px.list_backends

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # pandas_ext
 Python Pandas extensions for pandas dataframes
+
+
+# Usage
+
+```
+import pandas_ext as px
+
+px.read_csv
+px.to_csv
+
+px.read_gdrive
+px.to_gdrive
+
+px.read_parquet
+px.to_parquet
+
+px.read_sfdc
+px.sfdc_metadata
+px.patch_sfdc
+px.async_patch
+
+px.read_sql
+px.list_backends
+
+px.to_xml
+```

--- a/pandas_ext/__init__.py
+++ b/pandas_ext/__init__.py
@@ -15,7 +15,7 @@ from .csv import to_csv
 from .gdrive import read_gdrive, to_gdrive
 from .parquet import read_parquet, to_parquet
 from .sfdc import (
-    read_sfdc, sfdc_metadata, patch_sfdc, async_patch,
+    read_sfdc, sfdc_metadata, patch_sfdc, async_patch_sfdc,
 )
 from .sql import read_sql, list_backends
 

--- a/pandas_ext/__init__.py
+++ b/pandas_ext/__init__.py
@@ -9,3 +9,23 @@ __author__ = "Rich Fernandez, Sean Massot, Brian Tenazas"
 __email__ = "devs@newsela.com"
 
 __uri__ = "https://github.com/newsela/pandas_ext"
+
+import pandas as _pd
+from .csv import to_csv
+from .gdrive import read_gdrive, to_gdrive
+from .parquet import read_parquet, to_parquet
+from .sfdc import (
+    read_sfdc, sfdc_metadata, patch_sfdc, async_patch,
+)
+from .sql import read_sql, list_backends
+
+read_csv = _pd.read_csv
+
+# Don't pollute the namespace with the module names:
+del common
+del csv
+del gdrive
+del parquet
+del sfdc
+del sql
+del _pd

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import re
 
 ###############################################################
 NAME = "pandas_ext"
-PACKAGES = find_packages(exclude=('tests', 'docs'))
+PACKAGES = ['pandas_ext']
 META_PATH = os.path.join("pandas_ext", "__init__.py")
 CLASSIFIERS = [
     'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import re
 
 ###############################################################
 NAME = "pandas_ext"
-PACKAGES = ['pandas_ext']
+PACKAGES = find_packages(exclude=('tests', 'docs'))
 META_PATH = os.path.join("pandas_ext", "__init__.py")
 CLASSIFIERS = [
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
E.g.

```
import pandas_ext as px
px.to_csv(df, 's3://...')
```

Also, `dir(px)` gives a concise list of functions available in the API.
Before, this would be:

```
import pandas_ext.csv
pandas_ext.csv.to_csv(df, 's3://...')
```

I found the `csv.to_csv` redundant.