### PR TITLE
Unpin the versions of dependencies

### DIFF
--- a/pandas_ext/__init__.py
+++ b/pandas_ext/__init__.py
@@ -1,5 +1,5 @@
 """Versioning kept here."""
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 __license__ = "MIT"
 
 __title__ = "pandas_ext"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --no-annotate --output-file requirements.txt requirements/requirements.in
 #
-boto3==1.9.37
-botocore==1.12.37
-certifi==2018.10.15
+boto3==1.9.75
+botocore==1.12.75
+certifi==2018.11.29
 chardet==3.0.4
 docutils==0.14
-idna==2.7
+idna==2.8
 jinja2==2.10
 jmespath==0.9.3
 markupsafe==1.1.0
@@ -18,10 +18,10 @@ pandas==0.23.4
 pyarrow==0.11.1
 pypandoc==1.4
 python-dateutil==2.6.1
-pytz==2018.7
-requests==2.20.0
-s3fs==0.1.6
+pytz==2018.9
+requests==2.21.0
+s3fs==0.2.0
 s3transfer==0.1.13
-six==1.11.0
+six==1.12.0
 urllib3==1.24.1
-wheel==0.32.2
+wheel==0.32.3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,7 @@
-Jinja2
-pandas
-pyarrow
-pypandoc
-requests
-s3fs
+Jinja2>=2.10
+pandas>=0.23.4
+pyarrow>=0.11.1
+pypandoc>=1.4
+requests>=2.20.0
+s3fs>=0.1.6
 python-dateutil<2.7.0,>=2.6.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ data manipulation.
 from pypandoc import convert
 from setuptools import find_packages, setup
 
-import codecs 
+import codecs
 import os
 import re
 
@@ -34,6 +34,7 @@ def read(*parts):
     with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
         return f.read()
 
+
 README = convert('README.md', 'rst')
 META_FILE = read(META_PATH)
 
@@ -50,6 +51,7 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError(f"Unable to find __{meta}__ string.")
+
 
 setup(
     name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     url=find_meta("uri"),
     version=find_meta("version"),
     license=find_meta("license"),
-    install_requires=read("requirements.txt"),
+    install_requires=read("requirements/requirements.in"),
     long_description=README,
     packages=PACKAGES,
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Specify a minimum version instead.

This resolves a blocker to installing pandas_ext in a Sagemaker or Docker environment. Otherwise, the pinned versions conflict with versions from other packages installed alongside pandas_ext.


Some tests don't pass, but they also don't pass in the master branch:

```
tests/test_gdrive.py::test_metadata                
tests/test_csv.py::test      
[gw0] [ 16%] PASSED tests/test_csv.py::test             
tests/test_gdrive.py::test_metadata_fetch_all
[gw1] [ 33%] ERROR tests/test_gdrive.py::test_metadata
tests/test_gdrive.py::test_gdrive_writes
[gw0] [ 50%] ERROR tests/test_gdrive.py::test_metadata_fetch_all      
tests/test_parquet.py::test                                                                                                                             
[gw1] [ 66%] ERROR tests/test_gdrive.py::test_gdrive_writes                 
tests/test_sqla_utils.py::test                                                                                                                         
[gw1] [ 83%] FAILED tests/test_sqla_utils.py::test                        
[gw0] [100%] PASSED tests/test_parquet.py::test Coverage.py warning: No data was collected. (no-data-collected) 
```