### PR TITLE
Don't convert README.md to RST in long description,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+.pytest_cache/

--- a/pandas_ext/__init__.py
+++ b/pandas_ext/__init__.py
@@ -1,5 +1,5 @@
 """Versioning kept here."""
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 __license__ = "MIT"
 
 __title__ = "pandas_ext"

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ markupsafe==1.1.0
 numpy==1.15.4
 pandas==0.23.4
 pyarrow==0.11.1
-pypandoc==1.4
 python-dateutil==2.6.1
 pytz==2018.9
 requests==2.21.0
@@ -24,4 +23,3 @@ s3fs==0.2.0
 s3transfer==0.1.13
 six==1.12.0
 urllib3==1.24.1
-wheel==0.32.3

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,6 @@
 Jinja2>=2.10
 pandas>=0.23.4
 pyarrow>=0.11.1
-pypandoc>=1.4
 requests>=2.20.0
 s3fs>=0.1.6
 python-dateutil<2.7.0,>=2.6.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 Any additional repos that may require client-side libs to do
 data manipulation.
 """
-from pypandoc import convert
 from setuptools import find_packages, setup
 
 import codecs
@@ -35,7 +34,7 @@ def read(*parts):
         return f.read()
 
 
-README = convert('README.md', 'rst')
+README = read('README.md')
 META_FILE = read(META_PATH)
 
 
@@ -45,8 +44,7 @@ def find_meta(meta):
     """
 
     meta_match = re.search(
-        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta),
-        META_FILE, re.M
+        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta), META_FILE, re.M
     )
     if meta_match:
         return meta_match.group(1)


### PR DESCRIPTION
- Relieves the need for pypandoc during install time.
- After this change, pandas_ext installs successfully in a Docker environment

