### PR TITLE
Allow slightly older versions of required packages

### DIFF
--- a/pandas_ext/__init__.py
+++ b/pandas_ext/__init__.py
@@ -1,5 +1,5 @@
 """Versioning kept here."""
-__version__ = '0.4.7'
+__version__ = '0.4.8'
 __license__ = "MIT"
 
 __title__ = "pandas_ext"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --no-annotate --output-file requirements.txt requirements/requirements.in
 #
-boto3==1.9.75
-botocore==1.12.75
+boto3==1.9.83
+botocore==1.12.83
 certifi==2018.11.29
 chardet==3.0.4
 docutils==0.14
@@ -13,10 +13,10 @@ idna==2.8
 jinja2==2.10
 jmespath==0.9.3
 markupsafe==1.1.0
-numpy==1.15.4
+numpy==1.16.0
 pandas==0.23.4
-pyarrow==0.11.1
-python-dateutil==2.6.1
+pyarrow==0.12.0
+python-dateutil==2.7.5
 pytz==2018.9
 requests==2.21.0
 s3fs==0.2.0

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,5 @@
 Jinja2>=2.10
-pandas>=0.23.4
+pandas>=0.22
 pyarrow>=0.11.1
 requests>=2.20.0
-s3fs>=0.1.6
-python-dateutil<2.7.0,>=2.6.1
+s3fs>=0.1.5


### PR DESCRIPTION
This is to assist with installing alongside other packages with incompatible version ranges.